### PR TITLE
fix Config-only to read all of header before parsing

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -40,8 +40,7 @@ func decode(r io.Reader, configOnly bool) (image.Image, image.Config, error) {
 	_decode := mod.ExportedFunction("decode")
 
 	if configOnly {
-		data = make([]byte, heifMaxHeaderSize)
-		_, err = r.Read(data)
+		data, err = io.ReadAll(io.LimitReader(r, heifMaxHeaderSize))
 		if err != nil {
 			return nil, cfg, fmt.Errorf("read: %w", err)
 		}


### PR DESCRIPTION
Fixes gen2brain/heic#8
