### PR TITLE
fix DecodeConfig in dynamic mode too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -15,6 +14,27 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ matrix.go-version }}
+        go-version-file: go.mod
+    - name: "[macos] install libheif"
+      if: runner.os == 'macOS'
+      run: brew install libheif
+    - name: "[linux] install libheif"
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y libheif-dev libheif1
+    - name: "[windows] cache vcpkg artifacts"
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      id: vcpkg-cache
+      with:
+        path: C:\Users\runneradmin\AppData\Local\vcpkg\archives
+        key: vcpkg-libheif-v1
+    - name: "[windows] install libheif"
+      if: runner.os == 'Windows'
+      run: |
+        vcpkg install libheif:x64-windows
+        vcpkg integrate install
+        dir C:/vcpkg/installed/x64-windows/bin
+        Get-ChildItem -Path "C:\vcpkg\installed\x64-windows\bin\*.dll" | Copy-Item -Destination .
+        dir
     - name: Test
-      run: go test
+      run: go test -v -bench=. -benchtime=1x

--- a/decode_dynamic.go
+++ b/decode_dynamic.go
@@ -19,8 +19,7 @@ func decodeDynamic(r io.Reader, configOnly bool) (image.Image, image.Config, err
 	var data []byte
 
 	if configOnly {
-		data = make([]byte, heifMaxHeaderSize)
-		_, err = r.Read(data)
+		data, err = io.ReadAll(io.LimitReader(r, heifMaxHeaderSize))
 		if err != nil {
 			return nil, cfg, fmt.Errorf("read: %w", err)
 		}
@@ -188,6 +187,12 @@ func decodeDynamic(r io.Reader, configOnly bool) (image.Image, image.Config, err
 }
 
 func init() {
+	if runtime.GOOS == "windows" {
+		dynamic = false
+		dynamicErr = fmt.Errorf("dynamic library loading not supported on windows yet; see https://github.com/gen2brain/heic/issues/11")
+		return
+	}
+
 	var err error
 	defer func() {
 		if r := recover(); r != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/gen2brain/heic
 go 1.23
 
 require (
-	github.com/ebitengine/purego v0.8.3
+	github.com/ebitengine/purego v0.9.1
 	github.com/tetratelabs/wazero v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/ebitengine/purego v0.8.3 h1:K+0AjQp63JEZTEMZiwsI9g0+hAMNohwUOtY0RPGexmc=
-github.com/ebitengine/purego v0.8.3/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/ebitengine/purego v0.9.1 h1:a/k2f2HQU3Pi399RPW1MOaZyhKJL9w/xFpKAg4q1s0A=
+github.com/ebitengine/purego v0.9.1/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=

--- a/heic.go
+++ b/heic.go
@@ -19,7 +19,7 @@ func Decode(r io.Reader) (image.Image, error) {
 	var err error
 	var img image.Image
 
-	if dynamic {
+	if dynamic && !ForceWasmMode {
 		img, _, err = decodeDynamic(r, false)
 		if err != nil {
 			return nil, err
@@ -39,7 +39,7 @@ func DecodeConfig(r io.Reader) (image.Config, error) {
 	var err error
 	var cfg image.Config
 
-	if dynamic {
+	if dynamic && !ForceWasmMode {
 		_, cfg, err = decodeDynamic(r, true)
 		if err != nil {
 			return image.Config{}, err
@@ -53,6 +53,15 @@ func DecodeConfig(r io.Reader) (image.Config, error) {
 
 	return cfg, nil
 }
+
+// ForceWasmMode, if true, forces using the WASM-based decoder even if a
+// dynamic/shared library is available.
+//
+// This exists mainly for testing purposes.
+//
+// It is not safe to change this concurrently with any other use of this
+// package.
+var ForceWasmMode bool
 
 // Dynamic returns error (if there was any) during opening dynamic/shared library.
 func Dynamic() error {

--- a/purego_darwin.go
+++ b/purego_darwin.go
@@ -3,8 +3,6 @@
 package heic
 
 import (
-	"fmt"
-
 	"github.com/ebitengine/purego"
 )
 
@@ -12,11 +10,15 @@ const (
 	libname = "libheif.dylib"
 )
 
-func loadLibrary() (uintptr, error) {
-	handle, err := purego.Dlopen(libname, purego.RTLD_NOW|purego.RTLD_GLOBAL)
-	if err != nil {
-		return 0, fmt.Errorf("cannot load library: %w", err)
+func loadLibrary() (handle uintptr, err error) {
+	for _, path := range []string{
+		libname,
+		"/opt/homebrew/lib/libheif.dylib",
+	} {
+		handle, err = purego.Dlopen(path, purego.RTLD_NOW|purego.RTLD_GLOBAL)
+		if err == nil {
+			return handle, nil
+		}
 	}
-
-	return uintptr(handle), nil
+	return 0, err
 }

--- a/purego_windows.go
+++ b/purego_windows.go
@@ -11,11 +11,20 @@ const (
 	libname = "libheif.dll"
 )
 
-func loadLibrary() (uintptr, error) {
-	handle, err := syscall.LoadLibrary(libname)
-	if err != nil {
-		return 0, fmt.Errorf("cannot load library %s: %w", libname, err)
+func loadLibrary() (handle uintptr, err error) {
+	paths := []string{
+		libname,
+		"heif.dll", // what vcpkg builds & names it
 	}
-
-	return uintptr(handle), nil
+	var firstErr error
+	for _, path := range paths {
+		sysHandle, err := syscall.LoadLibrary(path)
+		if err == nil {
+			return uintptr(sysHandle), nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	return 0, fmt.Errorf("cannot load library %s: %w", libname, firstErr)
 }


### PR DESCRIPTION
Like #9, but for dynamic mode.

And more tests. (including exporting a bool to let tests in callers
like Perkeep exercise both the wasm + dynamic code paths)

This also makes adds the common macOS homebrew libheif path as a
location that's tried in dynamic mode, and installs it for tests in
CI.
