### PR TITLE
fix build (by avoiding purego) on 32-bit GOARCH builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,54 @@ jobs:
         dir
     - name: Test
       run: go test -v -bench=. -benchtime=1x
+
+  # Test that we can at least cross-compile the package & tests on a variety
+  # of other platforms.
+  cross-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # don't abort the entire matrix if one element fails
+      matrix:
+        include:
+          # Note: {linux,windows,darwin}/amd64 is not in this matrix, because those
+          # are tested more exhaustively in the 'test' job above.
+          - goos: linux
+            goarch: "386" # quoted for yaml
+          - goos: linux
+            goarch: mips
+          - goos: linux
+            goarch: mipsle
+          - goos: linux
+            goarch: loong64
+          - goos: linux
+            goarch: arm
+            goarm: "5"
+          - goos: linux
+            goarch: arm
+            goarm: "7"
+          # Windows
+          - goos: windows
+            goarch: arm64
+          # BSDs
+          - goos: freebsd
+            goarch: amd64
+          - goos: openbsd
+            goarch: amd64
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+    - name: Install Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+    - name: build
+      env:
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
+        GOARM: ${{ matrix.goarm }}
+        CGO_ENABLED: "0"
+      run: |
+        go install ./...
+        go test --exec=true ./...
+

--- a/decode_dynamic.go
+++ b/decode_dynamic.go
@@ -1,4 +1,4 @@
-//go:build (unix || darwin || windows) && !nodynamic
+//go:build (linux || darwin || windows) && !(nodynamic || arm || 386 || mips || mipsle)
 
 package heic
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gen2brain/heic
 
-go 1.23
+go 1.25
 
 require (
 	github.com/ebitengine/purego v0.9.1

--- a/purego_other.go
+++ b/purego_other.go
@@ -1,4 +1,4 @@
-//go:build (!unix && !darwin && !windows) || nodynamic
+//go:build (!linux && !darwin && !windows) || android || nodynamic || arm || 386 || mips || mipsle
 
 package heic
 

--- a/purego_unix.go
+++ b/purego_unix.go
@@ -1,4 +1,4 @@
-//go:build unix && !darwin && !nodynamic
+//go:build linux && !android && !darwin && !(nodynamic || arm || 386 || mips || mipsle)
 
 package heic
 


### PR DESCRIPTION
This makes those architectures effectively always build in "nodynamic" mode without having to set the build tag.

Likewise, it disables dynamic mode (and use of "purego") on FreeBSD and OpenBSD where it wasn't compiling.