### PR TITLE
Bound sequence parser allocations to the input size

### DIFF
--- a/sequence.go
+++ b/sequence.go
@@ -136,7 +136,7 @@ func parseTrak(trak, data []byte) (*seqInfo, bool) {
 		case "stsd":
 			parseStsd(p, info)
 		case "stsz":
-			sizes = parseStsz(p)
+			sizes = parseStsz(p, len(data))
 		case "stco":
 			chunks = parseOffsets(p, 4)
 		case "co64":
@@ -144,7 +144,7 @@ func parseTrak(trak, data []byte) (*seqInfo, bool) {
 		case "stsc":
 			stsc = parseStsc(p)
 		case "stts":
-			info.durations = parseStts(p)
+			info.durations = parseStts(p, len(data))
 		}
 		return true
 	})
@@ -226,13 +226,27 @@ func parseHvcC(b []byte) (nalLenSize int, params [][]byte, ok bool) {
 	return nalLenSize, params, true
 }
 
-func parseStsz(p []byte) []int64 {
+// parseStsz reads the sample size table. The sample count is a 32-bit value
+// taken directly from the file, so allocations derived from it are bounded:
+// per-entry sizes must be present in the box payload, and a uniform table
+// still implies one byte of media data per sample, so its count cannot
+// exceed the input size. Without these caps, a tiny forged stsz box forces
+// a multi-gigabyte allocation.
+func parseStsz(p []byte, maxSamples int) []int64 {
 	if len(p) < 12 {
 		return nil
 	}
 
 	uniform := binary.BigEndian.Uint32(p[4:8])
 	n := int(binary.BigEndian.Uint32(p[8:12]))
+
+	if uniform != 0 {
+		if n > maxSamples {
+			n = maxSamples
+		}
+	} else if n > (len(p)-12)/4 {
+		n = (len(p) - 12) / 4
+	}
 
 	out := make([]int64, n)
 	if uniform != 0 {
@@ -260,6 +274,11 @@ func parseOffsets(p []byte, sz int) []int64 {
 	}
 
 	n := int(binary.BigEndian.Uint32(p[4:8]))
+	if n > (len(p)-8)/sz {
+		// Chunk offsets must be present in the box payload.
+		n = (len(p) - 8) / sz
+	}
+
 	out := make([]int64, 0, n)
 	off := 8
 	for i := 0; i < n; i++ {
@@ -284,6 +303,11 @@ func parseStsc(p []byte) []int {
 	}
 
 	n := int(binary.BigEndian.Uint32(p[4:8]))
+	if n > (len(p)-8)/12 {
+		// Entries must be present in the box payload.
+		n = (len(p) - 8) / 12
+	}
+
 	out := make([]int, 0, n*2)
 	off := 8
 	for i := 0; i < n; i++ {
@@ -299,12 +323,20 @@ func parseStsc(p []byte) []int {
 	return out
 }
 
-func parseStts(p []byte) []uint32 {
+// parseStts reads the sample-to-decode-time deltas. The entry count is
+// bounded by the box payload and the expanded total (sum of per-entry
+// counts) by the input size, so a forged entry count cannot expand into a
+// huge slice.
+func parseStts(p []byte, maxSamples int) []uint32 {
 	if len(p) < 8 {
 		return nil
 	}
 
 	n := int(binary.BigEndian.Uint32(p[4:8]))
+	if n > (len(p)-8)/8 {
+		n = (len(p) - 8) / 8
+	}
+
 	var out []uint32
 	off := 8
 	for i := 0; i < n; i++ {
@@ -313,7 +345,7 @@ func parseStts(p []byte) []uint32 {
 		}
 		cnt := binary.BigEndian.Uint32(p[off : off+4])
 		delta := binary.BigEndian.Uint32(p[off+4 : off+8])
-		for c := uint32(0); c < cnt; c++ {
+		for c := uint32(0); c < cnt && len(out) < maxSamples; c++ {
 			out = append(out, delta)
 		}
 		off += 8

--- a/sequence.go
+++ b/sequence.go
@@ -226,12 +226,7 @@ func parseHvcC(b []byte) (nalLenSize int, params [][]byte, ok bool) {
 	return nalLenSize, params, true
 }
 
-// parseStsz reads the sample size table. The sample count is a 32-bit value
-// taken directly from the file, so allocations derived from it are bounded:
-// per-entry sizes must be present in the box payload, and a uniform table
-// still implies one byte of media data per sample, so its count cannot
-// exceed the input size. Without these caps, a tiny forged stsz box forces
-// a multi-gigabyte allocation.
+// parseStsz caps the count by the bytes present so forged counts can't force a huge allocation.
 func parseStsz(p []byte, maxSamples int) []int64 {
 	if len(p) < 12 {
 		return nil
@@ -241,11 +236,9 @@ func parseStsz(p []byte, maxSamples int) []int64 {
 	n := int(binary.BigEndian.Uint32(p[8:12]))
 
 	if uniform != 0 {
-		if n > maxSamples {
-			n = maxSamples
-		}
-	} else if n > (len(p)-12)/4 {
-		n = (len(p) - 12) / 4
+		n = min(n, maxSamples)
+	} else {
+		n = min(n, (len(p)-12)/4)
 	}
 
 	out := make([]int64, n)
@@ -274,10 +267,7 @@ func parseOffsets(p []byte, sz int) []int64 {
 	}
 
 	n := int(binary.BigEndian.Uint32(p[4:8]))
-	if n > (len(p)-8)/sz {
-		// Chunk offsets must be present in the box payload.
-		n = (len(p) - 8) / sz
-	}
+	n = min(n, (len(p)-8)/sz)
 
 	out := make([]int64, 0, n)
 	off := 8
@@ -303,10 +293,7 @@ func parseStsc(p []byte) []int {
 	}
 
 	n := int(binary.BigEndian.Uint32(p[4:8]))
-	if n > (len(p)-8)/12 {
-		// Entries must be present in the box payload.
-		n = (len(p) - 8) / 12
-	}
+	n = min(n, (len(p)-8)/12)
 
 	out := make([]int, 0, n*2)
 	off := 8
@@ -323,19 +310,14 @@ func parseStsc(p []byte) []int {
 	return out
 }
 
-// parseStts reads the sample-to-decode-time deltas. The entry count is
-// bounded by the box payload and the expanded total (sum of per-entry
-// counts) by the input size, so a forged entry count cannot expand into a
-// huge slice.
+// parseStts caps the entry count by the box payload and the expanded total by maxSamples.
 func parseStts(p []byte, maxSamples int) []uint32 {
 	if len(p) < 8 {
 		return nil
 	}
 
 	n := int(binary.BigEndian.Uint32(p[4:8]))
-	if n > (len(p)-8)/8 {
-		n = (len(p) - 8) / 8
-	}
+	n = min(n, (len(p)-8)/8)
 
 	var out []uint32
 	off := 8

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -1,0 +1,126 @@
+package heic
+
+import (
+	"bytes"
+	"encoding/binary"
+	"runtime"
+	"testing"
+)
+
+// box wraps payload in an ISO-BMFF box: 4-byte size, 4-byte type, payload.
+func box(typ string, payload []byte) []byte {
+	b := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint32(b[:4], uint32(8+len(payload)))
+	copy(b[4:8], typ)
+	copy(b[8:], payload)
+	return b
+}
+
+// forgedSequenceContainer builds a minimal HEIF sequence container whose stsz
+// box claims 2^29 samples. Pre-fix, heic.DecodeConfig allocated ~4 GiB for
+// this 124-byte file before failing; the parsers must now bound allocations
+// by what the input can actually back.
+func forgedSequenceContainer() []byte {
+	ftyp := make([]byte, 16)
+	binary.BigEndian.PutUint32(ftyp[:4], 16)
+	copy(ftyp[4:8], "ftyp")
+	copy(ftyp[8:12], "msf1")
+
+	stsz := make([]byte, 12)
+	binary.BigEndian.PutUint32(stsz[8:12], 1<<29) // forged sample_count
+	stbl := box("stbl", box("stsz", stsz))
+	mdhd := box("mdhd", make([]byte, 20))
+	hdlr := box("hdlr", append(make([]byte, 8), "pict"...))
+	mdia := box("mdia", append(append(mdhd, hdlr...), box("minf", stbl)...))
+	moov := box("moov", box("trak", mdia))
+	return append(ftyp, moov...)
+}
+
+func TestParseStszBoundsForgedCounts(t *testing.T) {
+	// Per-entry sizes: count must be backed by bytes in the box payload.
+	p := make([]byte, 12)
+	binary.BigEndian.PutUint32(p[8:12], 1<<30)
+	if got := parseStsz(p, 1<<30); len(got) != 0 {
+		t.Fatalf("empty payload: got %d entries, want 0", len(got))
+	}
+
+	p = make([]byte, 12+2*4)
+	binary.BigEndian.PutUint32(p[8:12], 1<<30)
+	if got := parseStsz(p, 1<<30); len(got) != 2 {
+		t.Fatalf("2 entries present: got %d, want 2", len(got))
+	}
+
+	// Uniform table: count capped by maxSamples, not the forged value.
+	p = make([]byte, 12)
+	binary.BigEndian.PutUint32(p[4:8], 100) // sample_size
+	binary.BigEndian.PutUint32(p[8:12], 1<<30)
+	if got := parseStsz(p, 16); len(got) != 16 {
+		t.Fatalf("uniform forged count: got %d, want 16", len(got))
+	}
+	binary.BigEndian.PutUint32(p[8:12], 10)
+	if got := parseStsz(p, 16); len(got) != 10 {
+		t.Fatalf("uniform legit count: got %d, want 10", len(got))
+	}
+}
+
+func TestParseOffsetsBoundsForgedCounts(t *testing.T) {
+	p := make([]byte, 8)
+	binary.BigEndian.PutUint32(p[4:8], 1<<30)
+	if got := parseOffsets(p, 4); len(got) != 0 {
+		t.Fatalf("empty payload: got %d chunks, want 0", len(got))
+	}
+
+	p = make([]byte, 8+2*4)
+	binary.BigEndian.PutUint32(p[4:8], 1<<30)
+	if got := parseOffsets(p, 4); len(got) != 2 {
+		t.Fatalf("2 offsets present: got %d, want 2", len(got))
+	}
+}
+
+func TestParseStscBoundsForgedCounts(t *testing.T) {
+	p := make([]byte, 8)
+	binary.BigEndian.PutUint32(p[4:8], 1<<30)
+	if got := parseStsc(p); len(got) != 0 {
+		t.Fatalf("empty payload: got %d values, want 0", len(got))
+	}
+
+	p = make([]byte, 8+3*12)
+	binary.BigEndian.PutUint32(p[4:8], 1<<30)
+	if got := parseStsc(p); len(got) != 6 {
+		t.Fatalf("3 entries present: got %d values, want 6", len(got))
+	}
+}
+
+func TestParseSttsBoundsForgedCounts(t *testing.T) {
+	// One entry claiming 2^30 samples: expanded total capped by maxSamples.
+	p := make([]byte, 16)
+	binary.BigEndian.PutUint32(p[4:8], 1)      // one entry
+	binary.BigEndian.PutUint32(p[8:12], 1<<30) // cnt
+	binary.BigEndian.PutUint32(p[12:16], 1)    // delta
+	if got := parseStts(p, 64); len(got) != 64 {
+		t.Fatalf("forged cnt: got %d durations, want 64", len(got))
+	}
+
+	// Entry count itself capped by box payload.
+	p = make([]byte, 8)
+	binary.BigEndian.PutUint32(p[4:8], 1<<30)
+	if got := parseStts(p, 1<<30); len(got) != 0 {
+		t.Fatalf("empty payload: got %d durations, want 0", len(got))
+	}
+}
+
+func TestDecodeConfigDoesNotAmplifyForgedSequenceCounts(t *testing.T) {
+	data := forgedSequenceContainer()
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	if _, err := DecodeConfig(bytes.NewReader(data)); err == nil {
+		t.Fatal("expected decode failure for forged sequence")
+	}
+	runtime.ReadMemStats(&after)
+
+	if delta := after.TotalAlloc - before.TotalAlloc; delta > 64<<20 {
+		t.Fatalf("DecodeConfig allocated %.1f MiB for a %d-byte forged file, want <= 64 MiB",
+			float64(delta)/(1<<20), len(data))
+	}
+}

--- a/sequence_test.go
+++ b/sequence_test.go
@@ -16,10 +16,7 @@ func box(typ string, payload []byte) []byte {
 	return b
 }
 
-// forgedSequenceContainer builds a minimal HEIF sequence container whose stsz
-// box claims 2^29 samples. Pre-fix, heic.DecodeConfig allocated ~4 GiB for
-// this 124-byte file before failing; the parsers must now bound allocations
-// by what the input can actually back.
+// forgedSequenceContainer builds a 124-byte file whose stsz box claims 2^29 samples.
 func forgedSequenceContainer() []byte {
 	ftyp := make([]byte, 16)
 	binary.BigEndian.PutUint32(ftyp[:4], 16)
@@ -37,7 +34,7 @@ func forgedSequenceContainer() []byte {
 }
 
 func TestParseStszBoundsForgedCounts(t *testing.T) {
-	// Per-entry sizes: count must be backed by bytes in the box payload.
+	// Per-entry variant: count capped by payload bytes.
 	p := make([]byte, 12)
 	binary.BigEndian.PutUint32(p[8:12], 1<<30)
 	if got := parseStsz(p, 1<<30); len(got) != 0 {
@@ -50,7 +47,7 @@ func TestParseStszBoundsForgedCounts(t *testing.T) {
 		t.Fatalf("2 entries present: got %d, want 2", len(got))
 	}
 
-	// Uniform table: count capped by maxSamples, not the forged value.
+	// Uniform variant: count capped by maxSamples.
 	p = make([]byte, 12)
 	binary.BigEndian.PutUint32(p[4:8], 100) // sample_size
 	binary.BigEndian.PutUint32(p[8:12], 1<<30)
@@ -92,7 +89,7 @@ func TestParseStscBoundsForgedCounts(t *testing.T) {
 }
 
 func TestParseSttsBoundsForgedCounts(t *testing.T) {
-	// One entry claiming 2^30 samples: expanded total capped by maxSamples.
+	// Expanded total capped by maxSamples.
 	p := make([]byte, 16)
 	binary.BigEndian.PutUint32(p[4:8], 1)      // one entry
 	binary.BigEndian.PutUint32(p[8:12], 1<<30) // cnt
@@ -101,7 +98,7 @@ func TestParseSttsBoundsForgedCounts(t *testing.T) {
 		t.Fatalf("forged cnt: got %d durations, want 64", len(got))
 	}
 
-	// Entry count itself capped by box payload.
+	// Entry count capped by payload bytes.
 	p = make([]byte, 8)
 	binary.BigEndian.PutUint32(p[4:8], 1<<30)
 	if got := parseStts(p, 1<<30); len(got) != 0 {


### PR DESCRIPTION
## Summary

The HEIC sequence sample-table parsers (`parseStsz`, `parseOffsets`, `parseStsc`, `parseStts` in `sequence.go`) size their slices directly from 32-bit counts read from the file, without checking that the input can back them.

Reproduction: a **124-byte** `ftypmsf1` file with a `pict` track whose `stsz` box claims `sample_count = 0x20000000` forces a **4.0 GiB allocation** inside `heic.DecodeConfig` (measured via `runtime.MemStats`), before any decode or dimension check. A 10 MB body cap doesn't help — forged counts need no backing data. `parseStts` has the same amplification via an unbounded inner loop over a per-entry count.

## Fix

Allocations are now bounded by data actually present in the input:

- `parseStsz` — per-entry sizes must fit the box payload (`(len(p)-12)/4`); a uniform table implies one byte of media data per sample, so its count is capped by the input size.
- `parseOffsets` / `parseStsc` — entry counts capped by the box payload length.
- `parseStts` — entry count capped by the payload; the expanded duration total capped by the input size.

`parseTrak` already has the full input in hand (`data`), so the input-size bound is passed down with no signature churn to the public API. Worst-case allocation is now proportional to the input (~30x, from the tables themselves), instead of unbounded.

## Tests

- Same-package bounds tests for each parser with forged counts.
- `TestDecodeConfigDoesNotAmplifyForgedSequenceCounts` — the 124-byte forged container must fail fast allocating < 64 MiB (pre-fix: ~4 GiB).
- Legit sequences unaffected: full suite incl. `TestDecodeAll` (17-frame `anim.heic`) passes; benches and the `wasm2go` build are clean.

Found via KopiChange's review of a v0.7.1 consumer; the fix there guards at the boundary, this bounds the parser for every consumer.